### PR TITLE
Fix Pods select field in BB Posts module

### DIFF
--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -57,8 +57,7 @@ function pods_beaver_init() {
 	add_action( 'fl_builder_loop_before_query', 'pods_beaver_fake_loop_add_actions');
 
 	// fore data_source: custom_query for posts modules
-	add_action( 'wp_enqueue_scripts', 'pods_beaver_enqueue_assets' ); //remove once 1.10.6 has been widely adopted
-	add_filter( 'fl_builder_render_module_settings_assets', 'pods_beaver_add_settings_form_assets', 10, 2 );
+	add_action( 'wp_enqueue_scripts', 'pods_beaver_enqueue_assets' );
 
 	// add additional pods settings to any posts module
 	add_action( 'fl_builder_loop_settings_before_form', 'pods_beaver_loop_settings_before_form', 10, 1 );
@@ -99,33 +98,11 @@ add_action( 'plugins_loaded', 'pods_beaver_admin_nag' );
  * @since 1.1.1
  */
 function pods_beaver_enqueue_assets() {
+	if ( FLBuilderModel::is_builder_active() ) {
+		$deps = 'fl-builder-layout-' . get_the_ID();
 
-	if ( FLBuilderModel::is_builder_active() && version_compare( FL_BUILDER_VERSION, '1.10.6', '<' ) ) {
-		wp_enqueue_script( 'pods-beaver-settings-form', PODS_BEAVER_URL . 'assets/js/settings-form.js', array(), null, false );
+		wp_enqueue_script( 'pods-beaver-settings-form', PODS_BEAVER_URL . 'assets/js/settings-form.js', array( $deps ), null, true );
 	}
-
-}
-
-/**
- * Add assets for BB version 1.10.6 and later
- *
- * @param string $assets
- * @param object $module
- *
- * @return string $assets
- *
- * @since 1.1.1
- */
-function pods_beaver_add_settings_form_assets( $assets, $module ) {
-	
-	$supported_modules = array( 'post-grid', 'post-slider', 'post-carousel', 'pp-content-grid', 'pp-custom-grid', 'pp-content-tiles', 'blog-posts' );
-	
-	if ( in_array( $module->slug, $supported_modules, true ) ) {
-		$assets .= '<script type="text/javascript" src="' . esc_url( PODS_BEAVER_URL . 'assets/js/settings-form.js' ) . '" class="fl-builder-settings-js-custom-query"></script>';
-	}
-
-	return $assets;
-	
 }
 
 /**


### PR DESCRIPTION
- Remove the module settings form assets inclusion method. It was good while it lasted... :-) (a filter was added by me/Bernhard to Beaver Builder in 1.10.6, but has been removed in v2.x)

- Included dependency checks to force the JS to enqueue at the right time. The JS is fine. Tested with BB 1.x and 2.x