### PR TITLE
Hook into Pods 2.7.26 shortcode current post detection filter

### DIFF
--- a/classes/class-pods-beaver-page-data.php
+++ b/classes/class-pods-beaver-page-data.php
@@ -17,6 +17,15 @@ final class PodsBeaverPageData {
 	static $pods = array();
 
 	/**
+	* Track the state similar to $query->fl_builder_loop, in_the_loop().
+	*
+	* @var array
+	*
+	* @since 1.3.5
+	*/
+	static private $pods_beaver_loop;
+	
+	/**
 	 * Add Beaver Builder group for Pods.
 	 *
 	 * @since 1.0
@@ -26,8 +35,27 @@ final class PodsBeaverPageData {
 		FLPageData::add_group( 'pods', array(
 			'label' => __( 'Pods Field from:', 'pods-beaver-builder-themer-add-on' ),
 		) );
-
+		
+		self::pods_beaver_loop_false();
 	}
+
+	/**
+	 * Set $pods_beaver_loop
+	 *
+	 * @since 1.3.5
+	 */
+	public static function pods_beaver_loop_true() {
+		self::$pods_beaver_loop = true;
+	}
+
+	/**
+	 * Set $pods_beaver_loop
+	 *
+	 * @since 1.3.5
+	 */
+	public static function pods_beaver_loop_false() {
+		self::$pods_beaver_loop = false;
+	}	
 
 	/**
 	 * Get current pod info.
@@ -44,6 +72,15 @@ final class PodsBeaverPageData {
 			'pod' => null,
 			'id'  => null,
 		);
+		
+		if ( self::$pods_beaver_loop ) {
+			// We are in a loop not caused by FLThemeBuilderFieldConnections::connect_all_layout_settings to trigger connect_settings()
+			$info = array(
+				'pod' => get_post_type(),
+				'id'  => get_the_ID(),
+			);
+			return $info;
+		}		
 
 		$queried_object = get_queried_object();
 
@@ -155,10 +192,6 @@ final class PodsBeaverPageData {
 								break;
 						}
 					}
-				} elseif ( 'fl_builder_node_settings' !== current_filter() && in_the_loop() ) {
-					// We are in a loop not caused by FLThemeBuilderFieldConnections::connect_all_layout_settings to trigger connect_settings()
-					$pod_name = get_post_type();
-					$item_id  = get_the_ID();
 				} else {
 					$info = self::get_current_pod_info();
 

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -115,8 +115,9 @@ function pods_beaver_enqueue_assets() {
  */
 function pods_beaver_fake_loop_start() {
 	add_filter( 'pods_shortcode_detect_from_current_post', '__return_true', 9 );
-	//properly clean up after the loop
-	add_action( 'loop_end', 'pods_beaver_fake_loop_end');
+
+	// Remove the hook after the end of the loop.
+	add_action( 'loop_end', 'pods_beaver_fake_loop_end' );
 }
 
 /**
@@ -530,4 +531,3 @@ function pods_beaver_freemius() {
 	}
 }
 add_action( 'pods_freemius_init', 'pods_beaver_freemius' );
-

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pods Beaver Themer Add-On
  * Plugin URI: http://pods.io/
  * Description: Integration with Beaver Builder Themer (https://www.wpbeaverbuilder.com). Provides a UI for mapping Field Connections with Pods
- * Version: 1.3.4
+ * Version: 1.3.5
  * Author: Quasel, Pods Framework Team
  * Author URI: http://pods.io/about/
  * Text Domain: pods-beaver-builder-themer-add-on
@@ -30,7 +30,7 @@
  * @package Pods\Beaver Themer
  */
 
-define( 'PODS_BEAVER_VERSION', '1.3.4' );
+define( 'PODS_BEAVER_VERSION', '1.3.5' );
 define( 'PODS_BEAVER_FILE', __FILE__ );
 define( 'PODS_BEAVER_DIR', plugin_dir_path( PODS_BEAVER_FILE ) );
 define( 'PODS_BEAVER_URL', plugin_dir_url( PODS_BEAVER_FILE ) );
@@ -81,10 +81,10 @@ add_action( 'fl_page_data_add_properties', 'pods_beaver_init' );
  */
 function pods_beaver_admin_nag() {
 
-	if ( is_admin() && ( ! class_exists( 'FLBuilder' ) || ! defined( 'PODS_VERSION' ) ) ) {
+	if ( is_admin() && ( ! class_exists( 'FLBuilder' ) || ! defined( 'PODS_VERSION' ) || version_compare( PODS_VERSION, '2.7.26', '<' ) ) {
 		printf(
 			'<div class="notice notice-error"><p>%s</p></div>',
-			esc_html__( 'Pods Beaver Themer requires that the Pods and Beaver Builder Themer plugins be installed and activated.', 'pods-beaver-builder-themer-add-on' )
+			esc_html__( 'Pods Beaver Themer requires that the Pods (2.7.26+) and Beaver Builder Themer plugins be installed and activated.', 'pods-beaver-builder-themer-add-on' )
 		);
 	}
 

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -110,25 +110,21 @@ function pods_beaver_enqueue_assets() {
 }
 
 /**
- * Register function to start the fake loop.
+ * Register function to tell Pods shortcodes to start detecting from the current post.
  *
  * @since 1.3.3
  */
 function pods_beaver_fake_loop_start() {
-
-	add_action( 'fl_builder_loop_before_query', 'pods_beaver_fake_loop_true');
-
+	add_filter( 'pods_shortcode_detect_from_current_post', '__return_true', 9 );
 }
 
 /**
- * Register function to end the fake loop.
+ * Register function to tell Pods shortcodes to stop detecting from the current post.
  *
  * @since 1.3.3
  */
 function pods_beaver_fake_loop_end() {
-
-	add_action( 'fl_builder_loop_after_query', 'pods_beaver_fake_loop_false');
-
+	remove_filter( 'pods_shortcode_detect_from_current_post', '__return_true', 9 );
 }
 
 /**

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -81,7 +81,7 @@ add_action( 'fl_page_data_add_properties', 'pods_beaver_init' );
  */
 function pods_beaver_admin_nag() {
 
-	if ( is_admin() && ( ! class_exists( 'FLBuilder' ) || ! defined( 'PODS_VERSION' ) || version_compare( PODS_VERSION, '2.7.26', '<' ) ) ) {
+	if ( ! class_exists( 'FLBuilder' ) || ! defined( 'PODS_VERSION' ) || version_compare( PODS_VERSION, '2.7.26', '<' ) ) {
 		printf(
 			'<div class="notice notice-error"><p>%s</p></div>',
 			esc_html__( 'Pods Beaver Themer requires that the Pods (2.7.26+) and Beaver Builder Themer plugins be installed and activated.', 'pods-beaver-builder-themer-add-on' )

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -54,7 +54,6 @@ function pods_beaver_init() {
 
 	// Fake being "in the loop" for any module using FLBuilderLoop::query() (see #15)
 	add_action( 'fl_builder_loop_before_query', 'pods_beaver_fake_loop_start');
-	add_action( 'fl_builder_loop_after_query', 'pods_beaver_fake_loop_end');
 
 	// Priority 0 to run before  FLThemeBuilderRulesLocation::set_preview_query() - Beaver Themer
 	// add_action( 'wp_enqueue_scripts', 'pods_beaver_enqueue_assets', 0 );
@@ -116,6 +115,8 @@ function pods_beaver_enqueue_assets() {
  */
 function pods_beaver_fake_loop_start() {
 	add_filter( 'pods_shortcode_detect_from_current_post', '__return_true', 9 );
+	//properly clean up after the loop
+	add_action( 'loop_end', 'pods_beaver_fake_loop_end');
 }
 
 /**

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -115,6 +115,7 @@ function pods_beaver_enqueue_assets() {
  */
 function pods_beaver_fake_loop_start() {
 	add_filter( 'pods_shortcode_detect_from_current_post', '__return_true', 9 );
+	PodsBeaverPageData::pods_beaver_loop_true();
 
 	// Remove the hook after the end of the loop.
 	add_action( 'loop_end', 'pods_beaver_fake_loop_end' );
@@ -127,6 +128,7 @@ function pods_beaver_fake_loop_start() {
  */
 function pods_beaver_fake_loop_end() {
 	remove_filter( 'pods_shortcode_detect_from_current_post', '__return_true', 9 );
+	PodsBeaverPageData::pods_beaver_loop_false();
 }
 
 /**

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -136,6 +136,7 @@ function pods_beaver_fake_loop_end() {
  * add_action( 'loop_start', 'pods_beaver_fake_loop_true' );
  *
  * @since 1.0
+ * @deprecated deprecated since version 1.3.5
  */
 function pods_beaver_fake_loop_true() {
 
@@ -153,6 +154,7 @@ function pods_beaver_fake_loop_true() {
  * add_action( 'loop_end', 'pods_beaver_fake_loop_false' );
  *
  * @since 1.0
+ * @deprecated deprecated since version 1.3.5
  */
 function pods_beaver_fake_loop_false() {
 

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -136,7 +136,7 @@ function pods_beaver_fake_loop_end() {
  * add_action( 'loop_start', 'pods_beaver_fake_loop_true' );
  *
  * @since 1.0
- * @deprecated deprecated since version 1.3.5
+ * @deprecated since version 1.3.5
  */
 function pods_beaver_fake_loop_true() {
 
@@ -154,7 +154,7 @@ function pods_beaver_fake_loop_true() {
  * add_action( 'loop_end', 'pods_beaver_fake_loop_false' );
  *
  * @since 1.0
- * @deprecated deprecated since version 1.3.5
+ * @deprecated since version 1.3.5
  */
 function pods_beaver_fake_loop_false() {
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pods Beaver Themer Add-On ===
-Contributors: quasel, sc0ttkclark, jimtrue, smarterdigitalltd, keraweb,
+Contributors: quasel, sc0ttkclark, jimtrue, smarterdigitalltd, keraweb, nicdford,
 Donate link: https://pods.io/friends-of-pods/
 Tags: pods, beaver builder, beaver themer
 Requires at least: 4.4

--- a/readme.txt
+++ b/readme.txt
@@ -72,9 +72,10 @@ You can use [GitHub Updater](https://github.com/afragen/github-updater). A simpl
 
 == Changelog ==
 
-= 1.3.5 - January 6th, 2021 =
+= 1.3.5 - January 7th, 2021 =
 * Required: This add-on now requires Pods 2.7.26+ in order to function fully with the latest fixes.
 * Fixed: Properly hook into the Beaver Themer loop functionality to tell the Pods shortcode to reference the current post in the loop.
+* Updated: Fixed Branch for Afragen Github Updater
 
 = 1.3.4 - December 30th, 2020 =
 * Fixed: Admin notices are now using the correct action for showing the message that Pods and Beaver Themer plugins (if not available) are required to use this plugin. #110

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: pods, beaver builder, beaver themer
 Requires at least: 4.4
 Tested up to: 5.6
 Requires PHP: 5.4
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -71,6 +71,10 @@ You can use [GitHub Updater](https://github.com/afragen/github-updater). A simpl
 5. Example for Templates or Magic Tags.
 
 == Changelog ==
+
+= 1.3.5 - January 6th, 2021 =
+* Required: This add-on now requires Pods 2.7.26+ in order to function fully with the latest fixes.
+* Fixed: Properly hook into the Beaver Themer loop functionality to tell the Pods shortcode to reference the current post in the loop.
 
 = 1.3.4 - December 30th, 2020 =
 * Fixed: Admin notices are now using the correct action for showing the message that Pods and Beaver Themer plugins (if not available) are required to use this plugin. #110

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pods Beaver Themer Add-On ===
-Contributors: quasel, sc0ttkclark, jimtrue, smarterdigitalltd
+Contributors: quasel, sc0ttkclark, jimtrue, smarterdigitalltd, keraweb,
 Donate link: https://pods.io/friends-of-pods/
 Tags: pods, beaver builder, beaver themer
 Requires at least: 4.4

--- a/readme.txt
+++ b/readme.txt
@@ -72,10 +72,10 @@ You can use [GitHub Updater](https://github.com/afragen/github-updater). A simpl
 
 == Changelog ==
 
-= 1.3.5 - January 7th, 2021 =
+= 1.3.5 - January 8th, 2021 =
 * Required: This add-on now requires Pods 2.7.26+ in order to function fully with the latest fixes.
-* Fixed: Properly hook into the Beaver Themer loop functionality to tell the Pods shortcode to reference the current post in the loop.
-* Updated: Fixed Branch for Afragen Github Updater
+* Fixed: Properly hook into the Beaver Themer loop functionality to tell the Pods shortcode to reference the current post in the loop. #112 (@sc0ttkclark)
+* Updated: Fixed Branch for Afragen Github Updater.
 
 = 1.3.4 - December 30th, 2020 =
 * Fixed: Admin notices are now using the correct action for showing the message that Pods and Beaver Themer plugins (if not available) are required to use this plugin. #110


### PR DESCRIPTION
This hooks into the new Pods 2.7.26 filter added to shortcodes to detect current post (default: only if `in_the_loop()`)