### PR TITLE
Properly set post type param to fix issues with Polylang and possibly others.

### DIFF
--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -325,6 +325,9 @@ function pods_beaver_loop_before_query_settings( $settings ) {
 	 */
 	$field_params = apply_filters( 'pods_beaver_loop_settings_field_params', $field_params, $settings, $pod );
 
+	// Use post type wildcard by default.
+	$settings->post_type = 'any';
+
 	if ( $pod ) {
 		if ( $find_params ) {
 			// Optimized select only gets the ID
@@ -344,15 +347,15 @@ function pods_beaver_loop_before_query_settings( $settings ) {
 		    $field_params['output'] = 'id';
 			$ids = $pod->field( $field_params );
 		}
+
+		// Add pod name as the post type query.
+		$settings->post_type = $pod->pod;
 	}
 
 	if ( empty( $ids ) ) {
 	    // No Fields found make sure the end result is an empty WP_Query
 		add_filter( 'fl_builder_loop_query', 'pods_beaver_empty_query' );
 	}
-
-	// we have id's no need to specify the type
-	$settings->post_type = 'any';
 
 	add_filter( 'fl_builder_loop_query_args', 'pods_beaver_uabb_blog_posts', 10, 1 );
 

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -350,6 +350,8 @@ function pods_beaver_loop_before_query_settings( $settings ) {
 
 		// Add pod name as the post type query.
 		$settings->post_type = $pod->pod;
+		// Add pod context to the settings so other filters can make use of this.
+		$settings->pod = $pod;
 	}
 
 	if ( empty( $ids ) ) {
@@ -427,6 +429,12 @@ function pods_beaver_uabb_blog_posts( $args ) {
 
 	$args['post_type'] = 'any';
 	remove_filter( 'fl_builder_loop_query_args', 'pods_beaver_uabb_blog_posts' );
+
+	// Set post type correctly if a Pod is found.
+	$pod = pods_v( 'pod', pods_v( 'settings', $args, array() ), null );
+	if ( $pod ) {
+		$args['post_type'] = $pod->pod;
+	}
 
 	return $args;
 }

--- a/pods-beaver-themer.php
+++ b/pods-beaver-themer.php
@@ -352,6 +352,14 @@ function pods_beaver_loop_before_query_settings( $settings ) {
 		$settings->post_type = $pod->pod;
 		// Add pod context to the settings so other filters can make use of this.
 		$settings->pod = $pod;
+		// Add relationship context.
+		if ( 'pods_relation' === $settings->pods_source_type && ! empty( $settings->pods_source_relation ) ) {
+			$field = $pod->fields( $settings->pods_source_relation );
+			if ( $field && ! empty( $field->pick_val ) ) {
+				$settings->post_type = $field->pick_val;
+				$settings->rel_pod = pods( $field->pick_val );
+			}
+		}
 	}
 
 	if ( empty( $ids ) ) {
@@ -431,7 +439,9 @@ function pods_beaver_uabb_blog_posts( $args ) {
 	remove_filter( 'fl_builder_loop_query_args', 'pods_beaver_uabb_blog_posts' );
 
 	// Set post type correctly if a Pod is found.
-	$pod = pods_v( 'pod', pods_v( 'settings', $args, array() ), null );
+	$settings = pods_v( 'settings', $args, array() );
+	$pod      = pods_v( 'pod', $settings, null );
+	$pod      = pods_v( 'rel_pod', $settings, $pod ); // Field relationship.
 	if ( $pod ) {
 		$args['post_type'] = $pod->pod;
 	}


### PR DESCRIPTION
Second try PR :) Prev: #109

> Setting the post type to any can cause edge case issues with other plugins and WP core.
>
> For non-translatable post types this will create compatibility issues with Polyland since adding any will trigger Polylang to add the language queries, even though the ID's might not be translatable.
>
>Other than that, setting any also affects WP default query to only include public posts. I can imagine edge cases where this might cause issues.

Added enhancement to the above for relationship fields.