### PR TITLE
Feature/add pods field option

### DIFF
--- a/classes/class-pods-beaver-page-data.php
+++ b/classes/class-pods-beaver-page-data.php
@@ -17,14 +17,14 @@ final class PodsBeaverPageData {
 	static $pods = array();
 
 	/**
-	* Track the state similar to $query->fl_builder_loop, in_the_loop().
-	*
-	* @var array
-	*
-	* @since 1.3.5
-	*/
+	 * Track the state similar to $query->fl_builder_loop, in_the_loop().
+	 *
+	 * @var array
+	 *
+	 * @since 1.3.5
+	 */
 	static private $pods_beaver_loop;
-	
+
 	/**
 	 * Add Beaver Builder group for Pods.
 	 *
@@ -80,7 +80,7 @@ final class PodsBeaverPageData {
 				'id'  => get_the_ID(),
 			);
 			return $info;
-		}		
+		}
 
 		$queried_object = get_queried_object();
 
@@ -261,7 +261,31 @@ final class PodsBeaverPageData {
 		$content = $pod->display( $settings->field );
 
 		return $content;
+	}
 
+	/**
+	 * Just Basic Field Value.
+	 *
+	 * @param object $settings
+	 * @param string $property
+	 *
+	 * @return string
+	 *
+	 * @since 1.3.8
+	 */
+	public static function get_field_value( $settings, $property ) {
+
+		$content = '';
+
+		$pod = self::get_pod( $settings );
+
+		if ( ! $pod || ! $pod->exists() ) {
+			return $content;
+		}
+
+		$content = $pod->field( $settings->field );
+
+		return $content;
 	}
 
 	/**

--- a/includes/pods-page-data.php
+++ b/includes/pods-page-data.php
@@ -36,6 +36,33 @@ FLPageData::add_post_property( 'pods_display', $data );
 FLPageData::add_post_property_settings_fields( 'pods_display', $form );
 
 /**
+ * Pods CPT / Taxonomy / Term as a $pod->field() value
+ */
+$data = array(
+	'label'        => __( 'Post, Page, or Term (Field Value)', 'pods-beaver-builder-themer-add-on' ),
+	'group'        => 'pods',
+	'type'         => array(
+		'string',
+		'html',
+		'custom_field',
+	),
+	'getter'       => 'PodsBeaverPageData::get_field_value',
+);
+
+$form = array(
+	'field' => array(
+		'type'        => 'select',
+		'label'       => __( 'Field Name', 'pods-beaver-builder-themer-add-on' ),
+		'options'     => 'PodsBeaverPageData::pods_get_fields',
+		'help'        => __( 'Field list options are based on the current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
+		'description' => __( 'List options are based on your current preview location. <br /><br />Not sure what a field value is? Check out the <a style="text-decoration: underline" href="https://docs.pods.io/code/pods/field/">Pods field() docs</a>.', 'pods-beaver-builder-themer-add-on' ),
+	),
+);
+
+FLPageData::add_post_property( 'pods_field', $data );
+FLPageData::add_post_property_settings_fields( 'pods_field', $form );
+
+/**
  * Pods Templates / Magic Tag
  */
 $data = array(

--- a/includes/pods-page-data.php
+++ b/includes/pods-page-data.php
@@ -113,7 +113,7 @@ FLPageData::add_post_property_settings_fields( 'pods_template', $form );
  * Pods Settings
  */
 $data = array(
-	'label'  => __( 'Settings, Author, User…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'Settings, Author, User', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'string',
@@ -143,7 +143,7 @@ FLPageData::add_site_property_settings_fields( 'pods_settings', $form );
  * Pods Photo (Image)
  */
 $data = array(
-	'label'  => __( 'Image: Post, Page, Term…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'Image: Post, Page, Term', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'photo',
@@ -211,7 +211,7 @@ FLPageData::add_post_property_settings_fields( 'pods_photo_manual', $form );
  * Pods Multiple Photos (Images)
  */
 $data = array(
-	'label'  => __( 'Images: Post, Page, Term…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'Images: Post, Page, Term', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'multiple-photos',
@@ -266,7 +266,7 @@ FLPageData::add_post_property_settings_fields( 'pods_multiple_photos_manual', $f
  * Pods Settings Photo (Image)
  */
 $data = array(
-	'label'  => __( 'Image: Settings, Author, User…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'Image: Settings, Author, User', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'photo',
@@ -303,7 +303,7 @@ FLPageData::add_site_property_settings_fields( 'pods_settings_photo', $form );
  * Pods Settings Multiple Photos (Images)
  */
 $data = array(
-	'label'  => __( 'Images: Settings, Author, User…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'Images: Settings, Author, User', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'multiple-photos',
@@ -338,7 +338,7 @@ FLPageData::add_site_property_settings_fields( 'pods_settings_multiple_photos', 
  * Pods CPT
  */
 $data = array(
-	'label'  => __( 'URL: Post, Page, Term…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'URL: Post, Page, Term', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'url',
@@ -368,7 +368,7 @@ FLPageData::add_post_property_settings_fields( 'pods_url', $form );
  * Pods Settings / User
  */
 $data = array(
-	'label'  => __( 'URL: Settings, Author, User…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'URL: Settings, Author, User', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'url',
@@ -398,10 +398,10 @@ FLPageData::add_site_property_settings_fields( 'pods_settings_url', $form );
  */
 
 /**
- * Pods CPT / TAX / …
+ * Pods CPT / Taxonomy
  */
 $data = array(
-	'label'        => __( 'Color: Post, Page, Term…', 'pods-beaver-builder-themer-add-on' ),
+	'label'        => __( 'Color: Post, Page, Term', 'pods-beaver-builder-themer-add-on' ),
 	'group'        => 'pods',
 	'type'         => array(
 		'color',
@@ -430,7 +430,7 @@ FLPageData::add_post_property_settings_fields( 'pods_color', $form );
  * Pods Settings
  */
 $data = array(
-	'label'  => __( 'Color: Settings, Author, User…', 'pods-beaver-builder-themer-add-on' ),
+	'label'  => __( 'Color: Settings, Author, User', 'pods-beaver-builder-themer-add-on' ),
 	'group'  => 'pods',
 	'type'   => array(
 		'color',

--- a/includes/pods-page-data.php
+++ b/includes/pods-page-data.php
@@ -27,8 +27,8 @@ $form = array(
 		'type'        => 'select',
 		'label'       => __( 'Field Name', 'pods-beaver-builder-themer-add-on' ),
 		'options'     => 'PodsBeaverPageData::pods_get_fields',
-		'help'        => __( 'Field list is based on current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
-		'description' => __( 'Based on preview location', 'pods-beaver-builder-themer-add-on' ),
+		'help'        => __( 'Field list options are based on the current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
+		'description' => __( 'List options are based on your current preview location. <br /><br />Not sure what a display value is? Check out the <a style="text-decoration: underline" href="https://docs.pods.io/code/pods/display/">Pods display() docs</a>.', 'pods-beaver-builder-themer-add-on' ),
 	),
 );
 
@@ -156,8 +156,8 @@ $form = array(
 		'type'        => 'select',
 		'label'       => __( 'Field Name', 'pods-beaver-builder-themer-add-on' ),
 		'options'     => 'PodsBeaverPageData::pods_get_image_fields',
-		'help'        => __( 'Field list is based on current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
-		'description' => __( 'Based on preview location', 'pods-beaver-builder-themer-add-on' ),
+		'help'        => __( 'Field list options are based on the current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
+		'description' => __( 'List options are based on your current preview location.', 'pods-beaver-builder-themer-add-on' ),
 	),
 	'image_size'  => array(
 		'type'    => 'photo-sizes',
@@ -224,8 +224,8 @@ $form = array(
 		'type'        => 'select',
 		'label'       => __( 'Field Name', 'pods-beaver-builder-themer-add-on' ),
 		'options'     => 'PodsBeaverPageData::pods_get_multiple_images_fields',
-		'help'        => __( 'Field list is based on current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
-		'description' => __( 'Based on preview location', 'pods-beaver-builder-themer-add-on' ),
+		'help'        => __( 'Field list options are based on the current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
+		'description' => __( 'List options are based on your current preview location.', 'pods-beaver-builder-themer-add-on' ),
 	),
 );
 
@@ -352,8 +352,8 @@ $form = array(
 		'type'        => 'select',
 		'label'       => __( 'Field Name', 'pods-beaver-builder-themer-add-on' ),
 		'options'     => 'PodsBeaverPageData::pods_get_url_fields',
-		'help'        => __( 'Field list is based on current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
-		'description' => __( 'Based on preview location', 'pods-beaver-builder-themer-add-on' ),
+		'help'        => __( 'Field list options are based on the current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
+		'description' => __( 'List options are based on your current preview location.', 'pods-beaver-builder-themer-add-on' ),
 	),
 );
 
@@ -414,8 +414,8 @@ $form = array(
 		'type'        => 'select',
 		'label'       => __( 'Field Name', 'pods-beaver-builder-themer-add-on' ),
 		'options'     => 'PodsBeaverPageData::pods_get_color_fields',
-		'help'        => __( 'Field list is based on current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
-		'description' => __( 'Based on preview location', 'pods-beaver-builder-themer-add-on' ),
+		'help'        => __( 'Field list options are based on the current "Preview as:" settings in the top left.', 'pods-beaver-builder-themer-add-on' ),
+		'description' => __( 'List options are based on your current preview location.', 'pods-beaver-builder-themer-add-on' ),
 	),
 );
 

--- a/includes/pods-page-data.php
+++ b/includes/pods-page-data.php
@@ -9,10 +9,10 @@
  */
 
 /**
- * Pods CPT / TAX / …
+ * Pods CPT / Taxonomy / Term as a $pod->display() value
  */
 $data = array(
-	'label'        => __( 'Post, Page, Term…', 'pods-beaver-builder-themer-add-on' ),
+	'label'        => __( 'Post, Page, or Term (Display Value)', 'pods-beaver-builder-themer-add-on' ),
 	'group'        => 'pods',
 	'type'         => array(
 		'string',


### PR DESCRIPTION
Adds the ability to get pods field values.

If a user sets up a custom-defined list and wants to return the value, currently they can only return the `display()` value. This PR allows the use of the `field()` method instead. This enables easier management of frontend logic in the BB Themer Layout Settings.

### Custom list of values, with long label values.
![image](https://user-images.githubusercontent.com/7292444/205153305-cdb2c1f0-6074-42ba-bc7b-0687b4490fe7.png)

### Themer Layout Settings using the shortcode result as a means of validating what layout should be shown.
![Screenshot 2022-12-01 at 1 28 35 PM](https://user-images.githubusercontent.com/7292444/205154223-b4bb4054-63dd-4184-aa27-49d15add13ae.png)





